### PR TITLE
Fix address slash

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -170,7 +170,7 @@ Format: `add id/EMPLOYEE_ID n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG]… [
   - The local-part should only contain alphanumeric characters and the special characters +_.-
   - The local-part may not start or end with special characters.
   - This is followed by a '@' and then a domain name. The domain name is made up of domain labels separated by periods (e.g. `u.nus.edu`).
-- Address must be: Any characters are valid
+- Address must be: Any characters are valid (except for `/`)
 - Skills and tags must be: [*Alphanumeric*](#alphanumeric), no spaces, each should be 50 characters or fewer
 
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**

--- a/src/main/java/seedu/address/model/employee/Address.java
+++ b/src/main/java/seedu/address/model/employee/Address.java
@@ -10,12 +10,14 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Address {
 
-    public static final String MESSAGE_CONSTRAINTS = "Addresses can take any values, and it should not be blank";
+    public static final String MESSAGE_CONSTRAINTS = "Addresses can take any values (except for /),"
+            + " and it should not be blank";
 
     /*
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
+    public static final String CONTAINS_FORWARD_SLASH = "^(?!.*[/]).*";
     public static final String VALIDATION_REGEX = "[^\\s].*";
 
     public final String value;
@@ -39,7 +41,7 @@ public class Address {
         // the command parser or the storage's json converter.
         assert test != null;
 
-        return test.matches(VALIDATION_REGEX);
+        return test.matches(CONTAINS_FORWARD_SLASH) && test.matches(VALIDATION_REGEX);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/employee/Address.java
+++ b/src/main/java/seedu/address/model/employee/Address.java
@@ -17,7 +17,6 @@ public class Address {
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String CONTAINS_FORWARD_SLASH = "^(?!.*[/]).*";
     public static final String VALIDATION_REGEX = "[^\\s].*";
 
     public final String value;
@@ -41,7 +40,8 @@ public class Address {
         // the command parser or the storage's json converter.
         assert test != null;
 
-        return test.matches(CONTAINS_FORWARD_SLASH) && test.matches(VALIDATION_REGEX);
+        // Address should not contain forward-slash (/)
+        return (!test.contains("/")) && test.matches(VALIDATION_REGEX);
     }
 
     @Override

--- a/src/test/java/seedu/address/model/employee/AddressTest.java
+++ b/src/test/java/seedu/address/model/employee/AddressTest.java
@@ -27,6 +27,15 @@ public class AddressTest {
         // invalid addresses
         assertFalse(Address.isValidAddress("")); // empty string
         assertFalse(Address.isValidAddress(" ")); // spaces only
+        assertFalse(Address.isValidAddress("/")); // slashes only
+        assertFalse(Address.isValidAddress("kent / ridge")); // address with slashes
+        assertFalse(Address.isValidAddress("kent/ ridge")); // address with slashes
+        assertFalse(Address.isValidAddress("kent /ridge")); // address with slashes
+        assertFalse(Address.isValidAddress("kent/ridge")); // address with slashes
+        assertFalse(Address.isValidAddress("kent s/ridge")); // address with prefix
+        assertFalse(Address.isValidAddress("kent t/ridge")); // address with prefix
+        assertFalse(Address.isValidAddress("kent n/ridge")); // address with prefix
+        assertFalse(Address.isValidAddress("kent p/12345678")); // address with prefix
 
         // valid addresses
         assertTrue(Address.isValidAddress("Blk 456, Den Road, #01-355"));


### PR DESCRIPTION
Fixes #279

UG at PE-D allowed for any characters. However, if the address contained a CLI prefix, that portion of the address onwards will be regarded as part of another field. This may cause other fields to be inadvertently updated. This "causes the software to misbehave" as we may accidentally store the wrong data.

E.g. `Kent Ridge p/o office` causes `o office` to be parsed as a phone number. 

We will update the input validation to prevent users from entering addresses with `/`.

![image](https://github.com/user-attachments/assets/b6ea2f65-fd5d-4118-8e24-793d9edd7ccf)
